### PR TITLE
Fix/last tx users 335

### DIFF
--- a/webapp/src/components/Accordion/index.js
+++ b/webapp/src/components/Accordion/index.js
@@ -87,7 +87,7 @@ const AccordionComponent = ({
         {(filterValues || []).map(({ label, value }) => {
           return (
             <MenuItem
-              key={value}
+              key={`${label}-${value}`}
               className={classes.menu}
               onClick={() => {
                 handleClose()

--- a/webapp/src/components/TableSearch/index.js
+++ b/webapp/src/components/TableSearch/index.js
@@ -171,7 +171,11 @@ const TablePages = ({
               classes={classes}
               numSelected={selected.length}
               onSelectAllClick={handleSelectAllClick}
-              rowCount={rows.length}
+              rowCount={
+                disableByStatus
+                  ? rows.filter(row => row.statusId === disableByStatus).length
+                  : rows.length
+              }
               showColumnCheck={showColumnCheck}
               headCells={headCells}
               showColumnButton={showColumnButton}
@@ -236,7 +240,7 @@ const TablePages = ({
                         )
                       }
 
-                      if (col.id === 'tx') {
+                      if (!!row[col.id] && col.id === 'tx') {
                         return (
                           <TableCell
                             key={`${labelId}-${index}`}
@@ -264,7 +268,7 @@ const TablePages = ({
                             [classes.mainColorRow]: col.useMainColor
                           })}
                         >
-                          {row[col.id]}
+                          {row[col.id] || '-'}
                         </TableCell>
                       )
                     })}

--- a/webapp/src/routes/Admin/index.js
+++ b/webapp/src/routes/Admin/index.js
@@ -97,7 +97,7 @@ const headCellUserApprovals = [
     label: 'Total Rewards'
   },
   {
-    id: 'txid',
+    id: 'tx',
     align: 'right',
     useMainColor: true,
     rowLink: false,
@@ -391,7 +391,8 @@ const Admin = () => {
           ),
           2
         ),
-        txid: getLastCharacters(trxid) || '-'
+        link: trxid,
+        tx: getLastCharacters(trxid)
       }
     })
 

--- a/webapp/src/routes/Terms/index.js
+++ b/webapp/src/routes/Terms/index.js
@@ -17,6 +17,7 @@ const Terms = () => {
       <RicardianContract
         contractName={mainConfig.affiliateAccount}
         httpEndpoint={sdkConfig.endpoint}
+        url={mainConfig.blockExplorer}
       />
     </Box>
   )


### PR DESCRIPTION
### Add transaction link in last tx field in User Management section

### What does this PR do?

- Resolve #335
- Use the correct url of the block explorer to access the Ricardian contract
- Fix the visual bug in the "Referral payment" section that when the user selects all the available options the user can't deactivate them with the checkbox in the table header

### Steps to test

1. Run the project locally
2. Sign up as an Admin user
3. Go to "User Managment" section
4. Search for a user with a last transaction
5. Check the link

### Screenshots

**Link to block explorer**
![imagen](https://user-images.githubusercontent.com/66583677/219219837-14c8542a-7ed8-43f1-94f3-d6b7dc10deab.png)

![imagen](https://user-images.githubusercontent.com/66583677/219220061-046ff6c1-a9db-400c-af13-659b02cf9c60.png)

**Fix UI bug**
![imagen](https://user-images.githubusercontent.com/66583677/219220213-91579bfa-907a-461c-b270-063a8cc5f06b.png)
